### PR TITLE
fix: preserve list filters and scroll position on back navigation

### DIFF
--- a/PAGE_STATE_PRESERVATION.md
+++ b/PAGE_STATE_PRESERVATION.md
@@ -1,0 +1,94 @@
+# Page State Preservation (filters + scroll on back navigation)
+
+## Problem
+
+Diving into an exercise or lexicon term and coming back lost everything:
+
+- **Filters were dropped.** On `/exicon` the `router.push` that wrote filters to the
+  URL had been commented out, so tags and the search box lived only in component
+  state. `getServerSideProps` re-ran on the way back with no query params, and the
+  list came back unfiltered.
+- **Infinite scroll depth was lost.** The list restarted at page 1 even though the
+  user had scrolled through several pages.
+- **Scroll position was lost.** Next.js' pages router forces a scroll to `{0, 0}`
+  on back/forward navigation unless `experimental.scrollRestoration` is enabled.
+- On `/lexicon` the search filter used `router.push`, so every debounced keystroke
+  added a history entry — the back button walked through them one at a time instead
+  of returning to the previous page. The letter filter wasn't in the URL at all.
+
+## Solution
+
+Three pieces, split by what each one is good at.
+
+### 1. Filters live in the URL
+
+Both list pages sync their filters to the URL with a shallow `router.replace`:
+
+- `/exicon` → `?query=…&tags=…`
+- `/lexicon` → `?query=…&letter=…`
+
+`replace` (not `push`) keeps history clean — one entry per visit to the list, not
+one per keystroke — and `scroll: false` stops the URL update from jumping to the
+top. Because the filters are in the URL, they come back with the history entry and
+`getServerSideProps` re-renders the correct filtered list. Filtered lists are now
+shareable and survive a reload too.
+
+### 2. Scroll offset + pagination depth: `hooks/useListPageState.ts`
+
+The URL can't carry "how far down the list the user was", so the hook snapshots
+`{ asPath, scrollY, itemCount, pageCount }` to `sessionStorage` when the user
+leaves the page, and on the way back:
+
+1. Confirms the visit is actually a return (the previous route was a page nested
+   under the list) and that the filters match what was saved.
+2. Calls `fetchNextPage()` until the list is as deep as it was.
+3. Restores the scroll offset, holding it briefly while images and the masonry
+   layout settle. Any real user gesture (wheel, touch, key, click) aborts the
+   restore immediately, and it gives up after a few seconds.
+
+Because the TanStack Query cache lives in `_app`, returning to the list normally
+rebuilds all loaded pages from cache instantly; step 2 only does real work after a
+reload or once the cache has expired (`gcTime` is now 30 minutes).
+
+Arriving from anywhere else — the nav bar, a tag link, an external link — is not a
+return, so the list opens fresh at the top.
+
+### 3. `components/ui/back-link.tsx`
+
+"Back to Exercises" / "Back to Lexicon" used a plain `<Link href="/exicon">`, which
+threw away the query string. `BackLink` goes back through history when the user
+really came from the list (restoring the URL and letting the list page restore its
+scroll), and otherwise links to the last list URL it remembers.
+
+`lib/navigation-history.ts` is the small tracker behind both this and the
+return-visit check; it records the previous in-app route on every route change.
+
+### Also fixed along the way
+
+- `experimental.scrollRestoration` is enabled, so back/forward stops jumping to the
+  top of *every* page (detail pages included), not just the two list pages.
+- `/exicon`'s server-rendered first page fetched 18 items while the client fetched
+  pages of 24, so items 19–24 were skipped between page 1 and page 2. Both now use
+  a single `PAGE_SIZE`.
+- Paginated results are de-duplicated by `_id` (`uniqueById`), since the SSR first
+  page and the API can order results slightly differently.
+
+## Adding this to another list page
+
+```tsx
+const { data, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteScroll(...);
+const items = uniqueById(data?.pages.flatMap(page => page.items) ?? []);
+
+useListPageState({
+  storageKey: '/my-list',      // the page's pathname
+  itemCount: items.length,
+  pageCount: data?.pages.length ?? 0,
+  hasNextPage: !!hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  isReady: !isLoading && items.length > 0
+});
+```
+
+Keep the page's filters in the URL as well, or the hook will (correctly) decline to
+restore a position that belongs to a different set of filters.

--- a/apps/web/components/ui/back-link.tsx
+++ b/apps/web/components/ui/back-link.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { cameFrom, pathnameOf } from '@/lib/navigation-history';
+import { getSavedListUrl } from '../../hooks/useListPageState';
+
+interface BackLinkProps {
+  /** The list route this link goes back to, e.g. `/exicon`. */
+  href: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * "Back to list" link that keeps the list's state.
+ *
+ * When the user actually came from the list we go back through history, which
+ * restores the URL (filters) and lets the list page put the scroll position
+ * back. Otherwise we link to the last list URL we remember, so filters survive
+ * even when there is no history entry to return to.
+ */
+export function BackLink({ href, className, children }: BackLinkProps) {
+  const router = useRouter();
+  const listPathname = pathnameOf(href);
+  const [target, setTarget] = useState(href);
+  const canGoBack = useRef(false);
+
+  useEffect(() => {
+    setTarget(getSavedListUrl(listPathname, href));
+    canGoBack.current = cameFrom(listPathname);
+  }, [href, listPathname]);
+
+  const handleClick = (event: React.MouseEvent) => {
+    // Let the browser handle modified clicks (new tab / window).
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+      return;
+    }
+
+    if (canGoBack.current) {
+      event.preventDefault();
+      router.back();
+    }
+  };
+
+  return (
+    <Link href={target} className={className} onClick={handleClick}>
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/hooks/useListPageState.ts
+++ b/apps/web/hooks/useListPageState.ts
@@ -1,0 +1,290 @@
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+import { getPreviousPath, pathnameOf } from '@/lib/navigation-history';
+
+/**
+ * Remembers where the user was in a paginated list (scroll offset, how many
+ * pages were loaded, and the filtered URL) and puts them back there when they
+ * return from a detail page.
+ *
+ * Filters themselves live in the URL, so they come back with the history entry.
+ * This hook covers the parts the URL can't carry: the infinite-scroll depth and
+ * the scroll offset.
+ */
+
+const STORAGE_PREFIX = 'exicon:list-state:';
+
+/** Snapshots older than this are ignored so a stale position never surprises the user. */
+const MAX_SNAPSHOT_AGE_MS = 30 * 60 * 1000;
+
+/** Stop trying to grow the list / nudge the scroll after this long. */
+const RESTORE_TIMEOUT_MS = 6000;
+
+/** How often the restore loop re-checks the list while it grows back. */
+const RESTORE_INTERVAL_MS = 80;
+
+/** How long to keep holding the restored offset while the layout settles. */
+const RESTORE_SETTLE_MS = 500;
+
+export interface ListSnapshot {
+  /** Full list URL, filters included, that produced this snapshot. */
+  asPath: string;
+  scrollY: number;
+  itemCount: number;
+  pageCount: number;
+  savedAt: number;
+}
+
+export function readListSnapshot(storageKey: string): ListSnapshot | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_PREFIX + storageKey);
+    if (!raw) {
+      return null;
+    }
+
+    const snapshot = JSON.parse(raw) as ListSnapshot;
+    if (typeof snapshot?.asPath !== 'string' || typeof snapshot?.scrollY !== 'number') {
+      return null;
+    }
+
+    return Date.now() - snapshot.savedAt <= MAX_SNAPSHOT_AGE_MS ? snapshot : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function writeListSnapshot(storageKey: string, snapshot: ListSnapshot) {
+  try {
+    window.sessionStorage.setItem(STORAGE_PREFIX + storageKey, JSON.stringify(snapshot));
+  } catch (error) {
+    // Ignore: state restoration is best-effort
+  }
+}
+
+/**
+ * The list URL (filters included) that a detail page should return to.
+ * Falls back to the plain list route when there is nothing remembered.
+ */
+export function getSavedListUrl(storageKey: string, fallback: string): string {
+  return readListSnapshot(storageKey)?.asPath ?? fallback;
+}
+
+interface UseListPageStateOptions {
+  /** Stable key for this list, normally the page's pathname (e.g. `/exicon`). */
+  storageKey: string;
+  /** Items currently rendered. */
+  itemCount: number;
+  /** Pages the infinite query currently holds. */
+  pageCount: number;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+  /** True once the list is showing real data rather than a loading state. */
+  isReady: boolean;
+  /**
+   * Whether arriving from `previousPath` should restore the snapshot.
+   * Defaults to "came from a page nested under this list".
+   */
+  shouldRestoreFrom?: (previousPath: string) => boolean;
+}
+
+export function useListPageState({
+  storageKey,
+  itemCount,
+  pageCount,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  isReady,
+  shouldRestoreFrom
+}: UseListPageStateOptions) {
+  const router = useRouter();
+  const [restoreTarget, setRestoreTarget] = useState<ListSnapshot | null>(null);
+
+  // Kept in a ref so the save handler and the restore loop always see current
+  // values without having to re-subscribe or restart.
+  const latest = useRef({
+    itemCount,
+    pageCount,
+    hasNextPage,
+    isFetchingNextPage,
+    isReady,
+    asPath: router.asPath,
+    fetchNextPage
+  });
+
+  useEffect(() => {
+    latest.current = {
+      itemCount,
+      pageCount,
+      hasNextPage,
+      isFetchingNextPage,
+      isReady,
+      asPath: router.asPath,
+      fetchNextPage
+    };
+  });
+
+  // Save a snapshot whenever the user leaves the page.
+  useEffect(() => {
+    const save = (destination?: string) => {
+      const { itemCount: items, pageCount: pages, asPath } = latest.current;
+
+      // Shallow URL updates (filter changes) stay on the page - nothing to restore.
+      if (destination && pathnameOf(destination) === pathnameOf(asPath)) {
+        return;
+      }
+
+      if (items === 0) {
+        return;
+      }
+
+      writeListSnapshot(storageKey, {
+        asPath,
+        scrollY: window.scrollY,
+        itemCount: items,
+        pageCount: pages,
+        savedAt: Date.now()
+      });
+    };
+
+    const saveOnHide = () => save();
+
+    router.events.on('routeChangeStart', save);
+    window.addEventListener('pagehide', saveOnHide);
+
+    return () => {
+      router.events.off('routeChangeStart', save);
+      window.removeEventListener('pagehide', saveOnHide);
+    };
+  }, [router, storageKey]);
+
+  // Decide once, on mount, whether this visit is a return that should be restored.
+  useEffect(() => {
+    const snapshot = readListSnapshot(storageKey);
+    if (!snapshot) {
+      return;
+    }
+
+    // Only restore when the filters match what was saved, otherwise the
+    // remembered offset belongs to a different list.
+    if (snapshot.asPath !== router.asPath) {
+      return;
+    }
+
+    if (snapshot.scrollY < 1 && snapshot.pageCount <= 1) {
+      return;
+    }
+
+    const previousPath = getPreviousPath();
+    if (!previousPath) {
+      return;
+    }
+
+    const isReturn = shouldRestoreFrom
+      ? shouldRestoreFrom(previousPath)
+      : pathnameOf(previousPath).startsWith(`${storageKey}/`);
+
+    if (isReturn) {
+      setRestoreTarget(snapshot);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Grow the list back to its previous depth, then put the scroll offset back.
+  useEffect(() => {
+    if (!restoreTarget) {
+      return;
+    }
+
+    const startedAt = Date.now();
+    let settledSince: number | null = null;
+    // A deliberate user gesture always wins over restoration.
+    const abortEvents = ['wheel', 'touchmove', 'keydown', 'mousedown'];
+    let interval: ReturnType<typeof setInterval> | undefined;
+
+    const cleanUp = () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+      abortEvents.forEach(event => window.removeEventListener(event, abort));
+    };
+
+    const finish = () => {
+      cleanUp();
+      setRestoreTarget(null);
+    };
+
+    const abort = () => finish();
+
+    /** Scrolls as close to the remembered offset as the current page allows. */
+    const applyScroll = () => {
+      const maxScroll = Math.max(document.documentElement.scrollHeight - window.innerHeight, 0);
+      const goal = Math.min(restoreTarget.scrollY, maxScroll);
+
+      if (Math.abs(window.scrollY - goal) > 2) {
+        window.scrollTo(0, goal);
+      }
+
+      return goal;
+    };
+
+    const tick = () => {
+      if (Date.now() - startedAt > RESTORE_TIMEOUT_MS) {
+        // Out of time: get as close as we can rather than leaving the user at the top.
+        applyScroll();
+        finish();
+        return;
+      }
+
+      const {
+        itemCount: items,
+        pageCount: pages,
+        hasNextPage: canLoadMore,
+        isFetchingNextPage: isLoadingMore,
+        isReady: ready,
+        fetchNextPage: loadMore
+      } = latest.current;
+
+      if (!ready) {
+        return;
+      }
+
+      if (pages < restoreTarget.pageCount && canLoadMore && !isLoadingMore) {
+        loadMore();
+        return;
+      }
+
+      const listIsBackToSize = items >= restoreTarget.itemCount || !canLoadMore;
+      if (!listIsBackToSize) {
+        return;
+      }
+
+      const goal = applyScroll();
+      if (goal < restoreTarget.scrollY - 2) {
+        // The page is still shorter than it was - wait for more content.
+        return;
+      }
+
+      // Hold the offset briefly: images and lazily measured layouts (masonry)
+      // can still shift things around right after the list renders.
+      if (settledSince === null) {
+        settledSince = Date.now();
+      } else if (Date.now() - settledSince > RESTORE_SETTLE_MS) {
+        finish();
+      }
+    };
+
+    abortEvents.forEach(event => window.addEventListener(event, abort, { passive: true }));
+    interval = setInterval(tick, RESTORE_INTERVAL_MS);
+    tick();
+
+    return cleanUp;
+  }, [restoreTarget]);
+
+  return { isRestoringState: restoreTarget !== null };
+}

--- a/apps/web/lib/navigation-history.ts
+++ b/apps/web/lib/navigation-history.ts
@@ -1,0 +1,101 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+/**
+ * Tracks the previous in-app route so a page can tell whether the user just
+ * arrived from a "dive in" (a detail page) or from somewhere else entirely.
+ * Persisted in sessionStorage so it survives a reload of the current page.
+ */
+
+const STORAGE_KEY = 'exicon:navigation-history';
+
+interface NavigationHistory {
+  current: string | null;
+  previous: string | null;
+}
+
+let history: NavigationHistory = { current: null, previous: null };
+let hydrated = false;
+
+/** Strips the query string and hash so only the page identity is compared. */
+export function pathnameOf(url: string): string {
+  return url.split(/[?#]/)[0];
+}
+
+function hydrate() {
+  if (hydrated || typeof window === 'undefined') {
+    return;
+  }
+  hydrated = true;
+
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const stored = JSON.parse(raw) as NavigationHistory;
+      history = {
+        current: typeof stored?.current === 'string' ? stored.current : null,
+        previous: typeof stored?.previous === 'string' ? stored.previous : null
+      };
+    }
+  } catch (error) {
+    // sessionStorage can be unavailable (private mode, embedded webviews)
+  }
+}
+
+function persist() {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  } catch (error) {
+    // Ignore: navigation tracking is best-effort
+  }
+}
+
+export function recordNavigation(url: string) {
+  hydrate();
+
+  if (history.current === url) {
+    return;
+  }
+
+  if (history.current && pathnameOf(history.current) === pathnameOf(url)) {
+    // Same page, different query (e.g. filters written with a shallow replace).
+    // Keep `previous` pointing at the last genuinely different page.
+    history.current = url;
+  } else {
+    history.previous = history.current;
+    history.current = url;
+  }
+
+  persist();
+}
+
+/** The last in-app URL visited before the current one, if any. */
+export function getPreviousPath(): string | null {
+  hydrate();
+  return history.previous;
+}
+
+/** True when the user arrived on the current page from `pathname`. */
+export function cameFrom(pathname: string): boolean {
+  const previous = getPreviousPath();
+  return !!previous && pathnameOf(previous) === pathname;
+}
+
+/** Mounted once in _app so every route change is recorded. */
+export function useNavigationHistory() {
+  const router = useRouter();
+
+  useEffect(() => {
+    recordNavigation(router.asPath);
+
+    const handleRouteChange = (url: string) => recordNavigation(url);
+
+    router.events.on('routeChangeStart', handleRouteChange);
+    router.events.on('hashChangeStart', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+      router.events.off('hashChangeStart', handleRouteChange);
+    };
+  }, [router]);
+}

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -5,6 +5,23 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Removes duplicate records by `_id`, keeping the first occurrence.
+ * Paginated results can overlap (the server-rendered first page and the API use
+ * slightly different sorting), which would otherwise render duplicate cards.
+ */
+export function uniqueById<T extends { _id: string }>(items: T[]): T[] {
+  const seen = new Set<string>();
+
+  return items.filter(item => {
+    if (seen.has(item._id)) {
+      return false;
+    }
+    seen.add(item._id);
+    return true;
+  });
+}
+
 export function titleCase(text: string): string {
   return text.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -13,7 +13,9 @@ const nextConfig = {
   },
   experimental: {
     legacyBrowsers: false,
-    browsersListForSwc: true
+    browsersListForSwc: true,
+    // Restore the scroll position on back/forward instead of jumping to the top
+    scrollRestoration: true
   },
   env: {
     NEXT_PUBLIC_VERCEL_URL: process.env.VERCEL_URL

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -5,16 +5,23 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
 import { MainLayout } from '@/components/layout/main-layout';
 import { ToastProvider } from '@/components/ui/toast-provider';
+import { useNavigationHistory } from '@/lib/navigation-history';
 
 export default function MyApp({
   Component,
   pageProps
 }: AppProps) {
+  // Tracks where the user came from so list pages can restore their state
+  // when the user returns from a detail page.
+  useNavigationHistory();
+
   const [queryClient] = useState(() => new QueryClient({
     defaultOptions: {
       queries: {
         staleTime: 5 * 60 * 1000, // 5 minutes
-        gcTime: 10 * 60 * 1000, // 10 minutes
+        // Keep list results around long enough that returning from a detail
+        // page can rebuild the list from cache instead of refetching it.
+        gcTime: 30 * 60 * 1000, // 30 minutes
       },
     },
   }));

--- a/apps/web/pages/exicon/[slug].tsx
+++ b/apps/web/pages/exicon/[slug].tsx
@@ -14,6 +14,7 @@ import { VideoPlayer } from '@/components/video-player';
 import { ExercisePlaceholderLarge } from '@/components/ui/exercise-placeholder-large';
 import { ExercisePlaceholder } from '@/components/ui/exercise-placeholder';
 import { ExerciseTextRenderer } from '@/components/ui/exercise-text-renderer';
+import { BackLink } from '@/components/ui/back-link';
 import { getExerciseBySlug } from '@/lib/api/exercise';
 import { Settings } from 'lucide-react';
 import { ExerciseMeta } from '@/components/meta/exercise-meta';
@@ -93,9 +94,9 @@ export default function ExerciseDetailPage({ exercise }: ExerciseDetailPageProps
       <div className="min-h-screen bg-gray-100 dark:bg-black flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-2xl font-bold mb-4">Exercise not found</h1>
-          <Link href="/exicon">
+          <BackLink href="/exicon">
             <Button variant="outline">Back to Exercises</Button>
-          </Link>
+          </BackLink>
         </div>
       </div>
     );
@@ -131,11 +132,11 @@ export default function ExerciseDetailPage({ exercise }: ExerciseDetailPageProps
 
       <div className="min-h-screen bg-gray-100 dark:bg-black">
         <div className="container mx-auto py-8">
-          {/* Back button */}
-          <Link href="/exicon" className="inline-flex items-center mb-6 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-white transition-colors">
+          {/* Back button - returns to the list with its filters and scroll position */}
+          <BackLink href="/exicon" className="inline-flex items-center mb-6 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-white transition-colors">
             <ChevronLeft className="h-4 w-4 mr-1" />
             Back to Exercises
-          </Link>
+          </BackLink>
 
           {/* Exercise header */}
           <div className="mb-8 pt-8">

--- a/apps/web/pages/exicon/index.tsx
+++ b/apps/web/pages/exicon/index.tsx
@@ -16,10 +16,12 @@ import { TagList } from '@/components/ui/tag-list';
 import { ActiveFilters } from '@/components/ui/active-filters';
 import { searchExercises, getAllExercises, getPopularTags } from '@/lib/api/exercise';
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
+import { useListPageState } from '../../hooks/useListPageState';
 import { useSession } from '@/lib/auth-client';
 import { usePermissions } from '@/lib/hooks/use-permissions';
 import { useDebounce } from '@/lib/hooks/use-debounce';
 import { WORKOUT_TAG_CATEGORIES, type WorkoutTag } from '@/types/workout-tags';
+import { uniqueById } from '@/lib/utils';
 import CSVDownloadButton from '@/components/ui/csv-download-button';
 
 interface ExiconPageProps {
@@ -31,12 +33,34 @@ interface ExiconPageProps {
   initialPage: number;
 }
 
+// Kept in sync between the server-rendered first page and the client fetches so
+// pagination offsets line up.
+const PAGE_SIZE = 24;
+
+// Normalizes the `tags` query param, which can be missing, a string or an array
+const parseTagsParam = (tags: string | string[] | undefined): string[] => {
+  if (!tags) {
+    return [];
+  }
+  const tagsArray = Array.isArray(tags) ? tags : [tags];
+  return tagsArray.filter(tag => typeof tag === 'string' && tag.length > 0);
+};
+
+const sameTags = (a: string[], b: string[]) => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((tag, index) => tag === sortedB[index]);
+};
+
 // Fetch function for TanStack Query
 const fetchExercises = async ({ pageParam = 1, queryKey }: any) => {
   const [, searchQuery, activeTags] = queryKey;
   const queryParams = new URLSearchParams();
   queryParams.append('page', pageParam.toString());
-  queryParams.append('limit', '24');
+  queryParams.append('limit', PAGE_SIZE.toString());
 
   if (searchQuery) {
     queryParams.append('query', searchQuery);
@@ -121,7 +145,10 @@ export default function ExiconPage({
     return () => window.removeEventListener('scroll', handleScroll);
   }, [showAllCategories, isMobile]);
 
-  // Update URL when filters change
+  // Keep the URL in sync with the active filters. This is what makes the filters
+  // survive a dive-in + back (and makes a filtered list shareable / reloadable).
+  // `replace` is used instead of `push` so typing a search doesn't fill history
+  // with one entry per keystroke, and `scroll: false` keeps the current position.
   useEffect(() => {
     // Only run if router is ready and we are on the /exicon page.
     // This check helps prevent premature execution or execution on other pages if this component were reused.
@@ -129,56 +156,30 @@ export default function ExiconPage({
       return;
     }
 
-    const newPushQuery: any = {};
-    if (searchQuery) { // searchQuery is component state
-      newPushQuery.query = searchQuery;
+    const newQuery: { query?: string; tags?: string[] } = {};
+    if (searchQuery) {
+      newQuery.query = searchQuery;
     }
-    if (activeTags && activeTags.length > 0) { // activeTags is component state
-      newPushQuery.tags = activeTags;
-    }
-
-    // Normalize current relevant query params from router.query for comparison
-    const currentRouterQueryNormalized: any = {};
-    if (router.query.query && typeof router.query.query === 'string') {
-      currentRouterQueryNormalized.query = router.query.query;
+    if (activeTags.length > 0) {
+      newQuery.tags = activeTags;
     }
 
-    let currentRouterTagsSorted: string[] = [];
-    if (router.query.tags) {
-      const tagsArray = Array.isArray(router.query.tags)
-        ? router.query.tags
-        : [router.query.tags as string];
-      // Ensure tags are strings and filter out empty ones, then sort for comparison
-      currentRouterTagsSorted = tagsArray
-        .filter(tag => typeof tag === 'string' && tag.length > 0)
-        .sort();
+    const currentQuery = typeof router.query.query === 'string' ? router.query.query : '';
+    const currentTags = parseTagsParam(router.query.tags);
+
+    if (currentQuery === (newQuery.query ?? '') && sameTags(currentTags, activeTags)) {
+      return;
     }
 
-    const newPushQueryString = newPushQuery.query || "";
-    const currentRouterQueryString = currentRouterQueryNormalized.query || "";
-
-    const newPushQueryTagsSorted = newPushQuery.tags ? [...newPushQuery.tags].sort() : [];
-
-    // Check if the new query would be identical to the current one
-    const isIdentical =
-      newPushQueryString === currentRouterQueryString &&
-      newPushQueryTagsSorted.length === currentRouterTagsSorted.length &&
-      newPushQueryTagsSorted.every((tag, index) => tag === currentRouterTagsSorted[index]);
-
-    if (!isIdentical) {
-      // TEMPORARILY COMMENTING OUT ROUTER.PUSH FOR DIAGNOSTICS
-      /*
-      router.push(
-        {
-          pathname: '/exicon',
-          query: newPushQuery,
-        },
-        undefined, // \`as\` parameter
-        { shallow: false } // Explicitly use default behavior (runs GSSP)
-      );
-      */
-    }
-  }, [searchQuery, activeTags, router.isReady, router.pathname, router.query]);
+    router.replace(
+      {
+        pathname: '/exicon',
+        query: newQuery,
+      },
+      undefined,
+      { shallow: true, scroll: false }
+    );
+  }, [searchQuery, activeTags, router]);
 
   // Use the custom infinite scroll hook
   // Only use initialData if current query matches the SSR initial query
@@ -193,6 +194,7 @@ export default function ExiconPage({
     error,
     isFetchingNextPage,
     hasNextPage,
+    fetchNextPage,
     loadMoreRef,
   } = useInfiniteScroll<ExerciseListItem>({
     queryKey: ['exercises', searchQuery, activeTags],
@@ -205,8 +207,22 @@ export default function ExiconPage({
   });
 
   // Flatten all exercises from all pages
-  const exercises = data?.pages.flatMap((page: { items: ExerciseListItem[]; totalCount: number }) => page.items) ?? [];
+  const exercises = uniqueById(
+    data?.pages.flatMap((page: { items: ExerciseListItem[]; totalCount: number }) => page.items) ?? []
+  );
   const currentTotalCount = data?.pages[0]?.totalCount ?? totalCount;
+
+  // Put the user back where they were when they return from an exercise page:
+  // reload the pages they had scrolled through, then restore the scroll offset.
+  useListPageState({
+    storageKey: '/exicon',
+    itemCount: exercises.length,
+    pageCount: data?.pages.length ?? 0,
+    hasNextPage: !!hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    isReady: !isLoading && exercises.length > 0
+  });
 
   const toggleTag = (tag: string) => {
     setActiveTags(prev =>
@@ -637,7 +653,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const currentPage = parseInt(page as string, 10) || 1;
   const searchQuery = query as string;
-  const selectedTags = Array.isArray(tags) ? tags as string[] : tags ? [tags as string] : [];
+  const selectedTags = parseTagsParam(tags as string | string[] | undefined);
 
   try {
     // Directly call the database functions instead of making HTTP requests
@@ -645,12 +661,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     if (searchQuery || selectedTags.length > 0) {
       // Use search function if there's a query or tags - explicitly pass status: 'active'
-      exercisesData = await searchExercises(searchQuery, selectedTags, currentPage, 18, {
+      exercisesData = await searchExercises(searchQuery, selectedTags, currentPage, PAGE_SIZE, {
         status: 'active'
       });
     } else {
       // Use getAllExercises for the default case - explicitly pass status: 'active'
-      exercisesData = await getAllExercises(currentPage, 18, {
+      exercisesData = await getAllExercises(currentPage, PAGE_SIZE, {
         status: 'active'
       });
     }

--- a/apps/web/pages/lexicon/[slug].tsx
+++ b/apps/web/pages/lexicon/[slug].tsx
@@ -8,6 +8,7 @@ import { LexiconItem, getLexiconItemBySlug } from '@/lib/api/lexicon';
 import { useSession } from '@/lib/auth-client';
 import { usePermissions } from '@/lib/hooks/use-permissions';
 import { ArrowLeft, Copy, BookOpen, Edit } from 'lucide-react';
+import { BackLink } from '@/components/ui/back-link';
 
 interface LexiconDetailPageProps {
   item: LexiconItem | null;
@@ -32,12 +33,12 @@ export default function LexiconDetailPage({ item, slug }: LexiconDetailPageProps
             <p className="text-gray-600 dark:text-gray-400 mb-6">
               The term &quot;{slug}&quot; was not found in our lexicon.
             </p>
-            <Link href="/lexicon">
+            <BackLink href="/lexicon">
               <Button>
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back to Lexicon
               </Button>
-            </Link>
+            </BackLink>
           </div>
         </div>
       </>
@@ -82,14 +83,14 @@ export default function LexiconDetailPage({ item, slug }: LexiconDetailPageProps
 
       <div className="min-h-screen bg-gray-100 dark:bg-black">
         <div className="container mx-auto py-6 px-4">
-          {/* Navigation */}
+          {/* Navigation - returns to the list with its filters and scroll position */}
           <div className="mb-8">
-            <Link href="/lexicon">
+            <BackLink href="/lexicon">
               <Button variant="ghost" className="flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white">
                 <ArrowLeft className="h-4 w-4" />
                 Back to Lexicon
               </Button>
-            </Link>
+            </BackLink>
           </div>
 
           {/* Main Content */}

--- a/apps/web/pages/lexicon/index.tsx
+++ b/apps/web/pages/lexicon/index.tsx
@@ -12,7 +12,9 @@ import { AlphabetNav } from '@/components/alphabet-nav';
 import { Spinner } from '@/components/ui/spinner';
 import { LexiconListItem, getAllLexiconItems, getLexiconItemsByLetter } from '@/lib/api/lexicon';
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
+import { useListPageState } from '../../hooks/useListPageState';
 import { useDebounce } from '@/lib/hooks/use-debounce';
+import { uniqueById } from '@/lib/utils';
 import { useSession } from '@/lib/auth-client';
 import { usePermissions } from '@/lib/hooks/use-permissions';
 import { BookOpen, Search, Copy, Plus } from 'lucide-react';
@@ -23,15 +25,20 @@ interface LexiconPageProps {
   totalCount: number;
   itemsByLetter: { [letter: string]: LexiconListItem[] };
   initialQuery: string;
+  initialLetter: string;
   initialPage: number;
 }
+
+// Kept in sync between the server-rendered first page and the client fetches so
+// pagination offsets line up.
+const PAGE_SIZE = 24;
 
 // Fetch function for TanStack Query
 const fetchLexiconItems = async ({ pageParam = 1, queryKey }: any) => {
   const [, searchQuery] = queryKey;
   const queryParams = new URLSearchParams();
   queryParams.append('page', pageParam.toString());
-  queryParams.append('limit', '24');
+  queryParams.append('limit', PAGE_SIZE.toString());
 
   if (searchQuery) {
     queryParams.append('query', searchQuery);
@@ -50,14 +57,14 @@ export default function LexiconPage({
   totalCount,
   itemsByLetter,
   initialQuery,
+  initialLetter,
   initialPage
 }: LexiconPageProps) {
   const router = useRouter();
   const { data: session } = useSession();
   const { data: permissions } = usePermissions();
   const [searchInput, setSearchInput] = useState(initialQuery);
-  const [activeLetter, setActiveLetter] = useState<string | undefined>();
-  const [displayItems, setDisplayItems] = useState<LexiconListItem[]>(initialItems);
+  const [activeLetter, setActiveLetter] = useState<string | undefined>(initialLetter || undefined);
   const [isScrolled, setIsScrolled] = useState(false);
 
   // Debounce the search input
@@ -94,43 +101,51 @@ export default function LexiconPage({
   const handleLetterClick = (letter: string) => {
     setActiveLetter(letter);
     setSearchInput(''); // Clear search when filtering by letter
-    const letterItems = itemsByLetter[letter] || [];
-    setDisplayItems(letterItems);
   };
 
   const handleShowAll = () => {
     setActiveLetter(undefined);
     setSearchInput(''); // Clear search
-    setDisplayItems(initialItems);
   };
 
-  // Update URL when search changes
+  // Keep the URL in sync with the search and letter filters. This is what makes
+  // the filters survive a dive-in + back (and makes the view shareable).
+  // `replace` is used instead of `push` so typing a search doesn't fill history
+  // with one entry per keystroke, and `scroll: false` keeps the current position.
   useEffect(() => {
     if (!router.isReady || router.pathname !== '/lexicon') {
       return;
     }
 
-    const newQuery: any = {};
+    const newQuery: { query?: string; letter?: string } = {};
     if (searchQuery) {
       newQuery.query = searchQuery;
     }
-
-    // Only update URL if different from current
-    const currentQuery = router.query.query as string || '';
-    if (searchQuery !== currentQuery) {
-      router.push(
-        {
-          pathname: '/lexicon',
-          query: newQuery,
-        },
-        undefined,
-        { shallow: true }
-      );
+    if (activeLetter) {
+      newQuery.letter = activeLetter;
     }
-  }, [searchQuery, router.isReady, router.pathname, router.query, router]);
 
-  // Use the custom infinite scroll hook for search AND default view
-  const isInitialQuery = searchQuery === initialQuery && !activeLetter;
+    const currentQuery = typeof router.query.query === 'string' ? router.query.query : '';
+    const currentLetter = typeof router.query.letter === 'string' ? router.query.letter : '';
+
+    if (currentQuery === (newQuery.query ?? '') && currentLetter === (newQuery.letter ?? '')) {
+      return;
+    }
+
+    router.replace(
+      {
+        pathname: '/lexicon',
+        query: newQuery,
+      },
+      undefined,
+      { shallow: true, scroll: false }
+    );
+  }, [searchQuery, activeLetter, router]);
+
+  // Use the custom infinite scroll hook for search AND default view.
+  // Letter filtering happens client-side against `itemsByLetter`, so it doesn't
+  // affect whether the server-rendered first page can seed the query.
+  const isInitialQuery = searchQuery === initialQuery;
 
   const {
     data,
@@ -139,6 +154,7 @@ export default function LexiconPage({
     error,
     isFetchingNextPage,
     hasNextPage,
+    fetchNextPage,
     loadMoreRef,
   } = useInfiniteScroll<LexiconListItem>({
     queryKey: ['lexicon', searchQuery],
@@ -151,18 +167,34 @@ export default function LexiconPage({
   });
 
   // Determine what items to show
+  const loadedItems = uniqueById(
+    data?.pages.flatMap((page: { items: LexiconListItem[]; totalCount: number }) => page.items) ?? initialItems
+  );
+
   let itemsToShow: LexiconListItem[] = [];
   let currentTotalCount = totalCount;
 
   if (activeLetter) {
-    // Show filtered by letter
-    itemsToShow = displayItems;
-    currentTotalCount = displayItems.length;
+    // Show filtered by letter (grouped items come from the server)
+    itemsToShow = itemsByLetter[activeLetter] ?? [];
+    currentTotalCount = itemsToShow.length;
   } else {
     // Show search results OR default view with infinite scroll
-    itemsToShow = data?.pages.flatMap((page: { items: LexiconListItem[]; totalCount: number }) => page.items) ?? displayItems;
+    itemsToShow = loadedItems;
     currentTotalCount = data?.pages[0]?.totalCount ?? totalCount;
   }
+
+  // Put the user back where they were when they return from a term page:
+  // reload the pages they had scrolled through, then restore the scroll offset.
+  useListPageState({
+    storageKey: '/lexicon',
+    itemCount: itemsToShow.length,
+    pageCount: data?.pages.length ?? 0,
+    hasNextPage: !activeLetter && !!hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    isReady: itemsToShow.length > 0
+  });
 
   const handleCopyDefinition = (title: string, description: string) => {
     console.log(`Copied definition for ${title}`);
@@ -437,11 +469,7 @@ export default function LexiconPage({
                 </p>
                 {(searchQuery || activeLetter) && (
                   <Button
-                    onClick={() => {
-                      setSearchInput('');
-                      setActiveLetter(undefined);
-                      setDisplayItems(initialItems);
-                    }}
+                    onClick={handleShowAll}
                     className="border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground"
                   >
                     Show all terms
@@ -457,16 +485,17 @@ export default function LexiconPage({
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { query = '', page = '1' } = context.query;
+  const { query = '', letter = '', page = '1' } = context.query;
 
   const currentPage = parseInt(page as string, 10) || 1;
   const searchQuery = query as string;
+  const activeLetter = (letter as string).slice(0, 1).toUpperCase();
 
   try {
     // Get initial items (first page)
     const initialData = searchQuery
-      ? await import('@/lib/api/lexicon').then(mod => mod.searchLexiconItems(searchQuery, currentPage, 24))
-      : await import('@/lib/api/lexicon').then(mod => mod.getAllLexiconItems(currentPage, 24));
+      ? await import('@/lib/api/lexicon').then(mod => mod.searchLexiconItems(searchQuery, currentPage, PAGE_SIZE))
+      : await import('@/lib/api/lexicon').then(mod => mod.getAllLexiconItems(currentPage, PAGE_SIZE));
 
     // Get items grouped by letter for alphabet navigation
     const itemsByLetter = await import('@/lib/api/lexicon').then(mod => mod.getLexiconItemsByLetter());
@@ -477,6 +506,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         totalCount: initialData.totalCount,
         itemsByLetter: JSON.parse(JSON.stringify(itemsByLetter)),
         initialQuery: searchQuery || '',
+        initialLetter: itemsByLetter[activeLetter] ? activeLetter : '',
         initialPage: currentPage
       }
     };
@@ -489,8 +519,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         totalCount: 0,
         itemsByLetter: {},
         initialQuery: searchQuery || '',
+        initialLetter: '',
         initialPage: currentPage
       }
     };
   }
-}; 
+};


### PR DESCRIPTION
Diving into an exercise or lexicon term and returning to the list lost the
active filters, the infinite-scroll depth and the scroll position.

- Sync filters to the URL on both list pages with a shallow `router.replace`
  (`scroll: false`), so they survive a dive-in + back, a reload and sharing.
  /exicon had its `router.push` commented out entirely; /lexicon used `push`,
  which added a history entry per debounced keystroke. The lexicon letter
  filter is now in the URL too.
- Add `useListPageState`, which snapshots the scroll offset and loaded page
  count to sessionStorage, then on a genuine return re-fetches pages up to the
  previous depth and restores the offset. A user gesture aborts it, and it only
  runs when the filters match what was saved.
- Add `BackLink` so "Back to Exercises"/"Back to Lexicon" returns through
  history (or to the last list URL) instead of dropping the query string.
- Enable `experimental.scrollRestoration` so back/forward no longer jumps to
  the top of every page, and raise the query cache gcTime to 30 minutes.
- Fix /exicon skipping items 19-24: the server rendered 18 items per page while
  the client fetched 24. De-duplicate paginated items by `_id`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011yz8ogZGHQ5sfgpxDojjHH